### PR TITLE
Print more information when compiler output is too long

### DIFF
--- a/dmoj/error.py
+++ b/dmoj/error.py
@@ -11,8 +11,14 @@ class InternalError(Exception):
 
 
 class OutputLimitExceeded(Exception):
-    def __init__(self, stream, limit):
-        super().__init__("exceeded %d-byte limit on %s stream" % (limit, stream))
+    def __init__(self, stream, limit, data=None):
+        if data is None:
+            super().__init__("exceeded %d-byte limit on %s stream" % (limit, stream))
+        else:
+            super().__init__(
+                "exceeded %d-byte limit on %s stream.\nFirst %d bytes of data: %s "
+                % (limit, stream, len(data), data.decode())
+            )
 
 
 class InvalidCommandException(Exception):

--- a/dmoj/executors/compiled_executor.py
+++ b/dmoj/executors/compiled_executor.py
@@ -214,8 +214,8 @@ class CompiledExecutor(BaseExecutor, metaclass=_CompiledExecutorMeta):
         limit = env.compiler_output_character_limit
         try:
             output = safe_communicate(process, None, outlimit=limit, errlimit=limit)[self.compile_output_index]
-        except OutputLimitExceeded:
-            output = b'compiler output too long (> 64kb)'
+        except OutputLimitExceeded as e:
+            output = b'compiler output too long (> 64kb)\nMore informations: ' + str(e).encode()
 
         if self.is_failed_compile(process):
             if process.timed_out:

--- a/dmoj/utils/communicate.py
+++ b/dmoj/utils/communicate.py
@@ -83,7 +83,8 @@ def safe_communicate(proc, input=None, outlimit=None, errlimit=None):
                 if fd2length[fd] > fd2limit[fd]:
                     proc.mark_ole()
                     raise OutputLimitExceeded(
-                        'stdout' if proc.stdout is not None and proc.stdout.fileno() == fd else 'stderr', fd2limit[fd]
+                        'stdout' if proc.stdout is not None and proc.stdout.fileno() == fd else 'stderr', fd2limit[fd],
+                        b''.join(fd2output[fd])[:1024]
                     )
             else:
                 # Ignore hang up or errors.


### PR DESCRIPTION
GCC can raise a very longggggggggggg compiler output, for example, this code can make GCC output more than 64KB of compile messages. 

```c++
#include <bits/stdc++.h>

int main()
{
    using namespace std;

    (make_pair(1ll, 1ll) != make_pair(1, 1));

    return 0;
}
```

Currently, DMOJ just simply displays a message "compiler output too long (> 64kb)", and it is not much useful. 

I added a bit information (the first 1024 bytes of compiler output):
![image](https://user-images.githubusercontent.com/23715841/118836149-d11c8800-b8ed-11eb-8f48-bfa2b95ca06d.png)
