### PR TITLE
Allow Scratch run time

### DIFF
--- a/.docker/Makefile
+++ b/.docker/Makefile
@@ -9,7 +9,7 @@ judge-tier1:
 	cd tier1 && docker build --build-arg TAG="${GIT_TAG}" -t vnoj/judge-tier1 -t vnoj/judge-tier1:$(TAG) .
 
 judge-tier2:
-	cd tier2 && docker build --build-arg TAG="${GIT_TAG}" -t dmoj/judge-tier2 -t dmoj/judge-tier2:$(TAG) .
+	cd tier2 && docker build --build-arg TAG="${GIT_TAG}" -t vnoj/judge-tier2 -t vnoj/judge-tier2:$(TAG) .
 
 judge-tier3:
-	cd tier3 && docker build --build-arg TAG="${GIT_TAG}" -t dmoj/judge-tier3 -t dmoj/judge-tier3:$(TAG) .
+	cd tier3 && docker build --build-arg TAG="${GIT_TAG}" -t vnoj/judge-tier3 -t vnoj/judge-tier3:$(TAG) .

--- a/.docker/Makefile
+++ b/.docker/Makefile
@@ -6,7 +6,7 @@ TAG ?= latest
 all: judge-tier1 judge-tier2 judge-tier3
 
 judge-tier1:
-	cd tier1 && docker build --build-arg TAG="${GIT_TAG}" -t dmoj/judge-tier1 -t dmoj/judge-tier1:$(TAG) .
+	cd tier1 && docker build --build-arg TAG="${GIT_TAG}" -t vnoj/judge-tier1 -t vnoj/judge-tier1:$(TAG) .
 
 judge-tier2:
 	cd tier2 && docker build --build-arg TAG="${GIT_TAG}" -t dmoj/judge-tier2 -t dmoj/judge-tier2:$(TAG) .

--- a/.docker/tier1/Dockerfile
+++ b/.docker/tier1/Dockerfile
@@ -1,23 +1,18 @@
 FROM dmoj/runtimes-tier1
 
 ARG TAG=master
-RUN apt-get update && apt-get install -y git cmake
-
-# Install scratch compiler
-RUN mkdir /scratch_compiler && cd /scratch_compiler && \
-	curl -L https://github.com/scraterpreter/scrapec/archive/master.tar.gz | tar -xz --strip-components=1 && \
-	pip3 install -e .
+RUN apt-get update && apt-get install -y npm 
 
 # Install scratch interpreter
 RUN mkdir /scratch_interpreter && cd /scratch_interpreter && \
-	curl -L https://github.com/khuebeo/scrape/archive/master.tar.gz | tar -xz --strip-components=1 && \
-	mkdir build && \
-	cd build && \
-	cmake .. && \
-	make install
+	curl -L https://github.com/VNOI-Admin/scratch-run/archive/master.tar.gz | tar -xz --strip-components=1 && \
+	npm install -g pkg && \
+	npm install && \
+	pkg index.js -t node12-linux-x64 && \
+	mv index /usr/bin/scratch-run
 
 RUN mkdir /judge /problems && cd /judge && \
-	curl -L https://github.com/VNOI-Admin/judge-server/archive/"${TAG}".tar.gz | tar -xz --strip-components=1 && \
+	curl -L https://github.com/VNOI-Admin/judge-server/archive/scratch.tar.gz | tar -xz --strip-components=1 && \
 	pip3 install -e . && \
 	HOME=~judge . ~judge/.profile && \
 	runuser -u judge -w PATH -- dmoj-autoconf -V > /judge-runtime-paths.yml && \

--- a/.docker/tier1/Dockerfile
+++ b/.docker/tier1/Dockerfile
@@ -1,18 +1,15 @@
 FROM dmoj/runtimes-tier1
 
 ARG TAG=master
-RUN apt-get update && apt-get install -y npm 
 
 # Install scratch interpreter
-RUN mkdir /scratch_interpreter && cd /scratch_interpreter && \
-	curl -L https://github.com/VNOI-Admin/scratch-run/archive/master.tar.gz | tar -xz --strip-components=1 && \
-	npm install -g pkg && \
-	npm install && \
-	pkg index.js -t node12-linux-x64 && \
-	mv index /usr/bin/scratch-run
+RUN curl --location -o scratch-run.zip https://github.com/VNOI-Admin/scratch-run/releases/download/0.0.2/scratch-run_0.0.2_linux_amd64.zip && \
+	unzip scratch-run.zip && \
+	mv scratch-run /usr/bin/scratch-run && \
+	rm scratch-run.zip
 
 RUN mkdir /judge /problems && cd /judge && \
-	curl -L https://github.com/VNOI-Admin/judge-server/archive/scratch.tar.gz | tar -xz --strip-components=1 && \
+	curl -L https://github.com/VNOI-Admin/judge-server/archive/"${TAG}".tar.gz | tar -xz --strip-components=1 && \
 	pip3 install -e . && \
 	HOME=~judge . ~judge/.profile && \
 	runuser -u judge -w PATH -- dmoj-autoconf -V > /judge-runtime-paths.yml && \

--- a/.docker/tier1/Dockerfile
+++ b/.docker/tier1/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 # Install scratch interpreter
-RUN curl --location -o scratch-run.zip https://github.com/VNOI-Admin/scratch-run/releases/download/0.0.2/scratch-run_0.0.2_linux_amd64.zip && \
+RUN curl --location -o scratch-run.zip $(curl -s https://api.github.com/repos/VNOI-Admin/scratch-run/releases/latest | grep -o -m 1 "https://github\.com.*.*linux_amd64\.zip") && \
 	unzip scratch-run.zip && \
 	mv scratch-run /usr/bin/scratch-run && \
 	rm scratch-run.zip

--- a/.docker/tier1/Dockerfile
+++ b/.docker/tier1/Dockerfile
@@ -11,5 +11,20 @@ RUN mkdir /judge /problems && cd /judge && \
 	g++ -std=c++17 -Wall -DONLINE_JUDGE -O2 -fmax-errors=5 -march=native -s /usr/include/testlib.h && \
 	find /usr/include/ -name stdc++.h -exec g++ -std=c++17 -Wall -DONLINE_JUDGE -O2 -fmax-errors=5 -march=native -s {} \;
 
+RUN apt-get update && apt-get install -y git cmake
+
+# Install scratch compiler
+RUN mkdir /scratch_compiler && cd /scratch_compiler && \
+	curl -L https://github.com/scraterpreter/scrapec/archive/master.tar.gz | tar -xz --strip-components=1 && \
+	pip3 install -e . && \
+	echo '  scrapec: /usr/local/bin/scrapec' >> /judge-runtime-paths.yml
+
+# Install scratch interpreter
+RUN mkdir /scratch_interpreter && cd /scratch_interpreter && \
+	curl -L https://github.com/khuebeo/scrape/archive/master.tar.gz | tar -xz --strip-components=1 && \
+	mkdir build && \
+	cd build && \
+	cmake .. && \
+	make install
 
 ENTRYPOINT ["/judge/.docker/entry"]

--- a/.docker/tier1/Dockerfile
+++ b/.docker/tier1/Dockerfile
@@ -1,23 +1,12 @@
 FROM dmoj/runtimes-tier1
 
 ARG TAG=master
-RUN mkdir /judge /problems && cd /judge && \
-	curl -L https://github.com/VNOI-Admin/judge-server/archive/"${TAG}".tar.gz | tar -xz --strip-components=1 && \
-	pip3 install -e . && \
-	HOME=~judge . ~judge/.profile && \
-	runuser -u judge -w PATH -- dmoj-autoconf -V > /judge-runtime-paths.yml && \
-	echo '  crt_x86_in_lib32: true' >> /judge-runtime-paths.yml && \
-	curl -L https://raw.githubusercontent.com/MikeMirzayanov/testlib/master/testlib.h -o /usr/include/testlib.h && \
-	g++ -std=c++17 -Wall -DONLINE_JUDGE -O2 -fmax-errors=5 -march=native -s /usr/include/testlib.h && \
-	find /usr/include/ -name stdc++.h -exec g++ -std=c++17 -Wall -DONLINE_JUDGE -O2 -fmax-errors=5 -march=native -s {} \;
-
 RUN apt-get update && apt-get install -y git cmake
 
 # Install scratch compiler
 RUN mkdir /scratch_compiler && cd /scratch_compiler && \
 	curl -L https://github.com/scraterpreter/scrapec/archive/master.tar.gz | tar -xz --strip-components=1 && \
-	pip3 install -e . && \
-	echo '  scrapec: /usr/local/bin/scrapec' >> /judge-runtime-paths.yml
+	pip3 install -e .
 
 # Install scratch interpreter
 RUN mkdir /scratch_interpreter && cd /scratch_interpreter && \
@@ -26,5 +15,16 @@ RUN mkdir /scratch_interpreter && cd /scratch_interpreter && \
 	cd build && \
 	cmake .. && \
 	make install
+
+RUN mkdir /judge /problems && cd /judge && \
+	curl -L https://github.com/VNOI-Admin/judge-server/archive/"${TAG}".tar.gz | tar -xz --strip-components=1 && \
+	pip3 install -e . && \
+	HOME=~judge . ~judge/.profile && \
+	runuser -u judge -w PATH -- dmoj-autoconf -V > /judge-runtime-paths.yml && \
+	echo '  crt_x86_in_lib32: true' >> /judge-runtime-paths.yml && \
+	echo '  scrapec: /usr/local/bin/scrapec' >> /judge-runtime-paths.yml && \
+	curl -L https://raw.githubusercontent.com/MikeMirzayanov/testlib/master/testlib.h -o /usr/include/testlib.h && \
+	g++ -std=c++17 -Wall -DONLINE_JUDGE -O2 -fmax-errors=5 -march=native -s /usr/include/testlib.h && \
+	find /usr/include/ -name stdc++.h -exec g++ -std=c++17 -Wall -DONLINE_JUDGE -O2 -fmax-errors=5 -march=native -s {} \;
 
 ENTRYPOINT ["/judge/.docker/entry"]

--- a/.docker/tier1/Dockerfile
+++ b/.docker/tier1/Dockerfile
@@ -22,7 +22,6 @@ RUN mkdir /judge /problems && cd /judge && \
 	HOME=~judge . ~judge/.profile && \
 	runuser -u judge -w PATH -- dmoj-autoconf -V > /judge-runtime-paths.yml && \
 	echo '  crt_x86_in_lib32: true' >> /judge-runtime-paths.yml && \
-	echo '  scrapec: /usr/local/bin/scrapec' >> /judge-runtime-paths.yml && \
 	curl -L https://raw.githubusercontent.com/MikeMirzayanov/testlib/master/testlib.h -o /usr/include/testlib.h && \
 	g++ -std=c++17 -Wall -DONLINE_JUDGE -O2 -fmax-errors=5 -march=native -s /usr/include/testlib.h && \
 	find /usr/include/ -name stdc++.h -exec g++ -std=c++17 -Wall -DONLINE_JUDGE -O2 -fmax-errors=5 -march=native -s {} \;

--- a/.docker/tier1/Dockerfile
+++ b/.docker/tier1/Dockerfile
@@ -2,6 +2,10 @@ FROM dmoj/runtimes-tier1
 
 ARG TAG=master
 
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends unzip && \
+    rm -rf /var/lib/apt/lists/*
+
 # Install scratch interpreter
 RUN curl --location -o scratch-run.zip https://github.com/VNOI-Admin/scratch-run/releases/download/0.0.2/scratch-run_0.0.2_linux_amd64.zip && \
 	unzip scratch-run.zip && \

--- a/.docker/tier2/Dockerfile
+++ b/.docker/tier2/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 # Install scratch interpreter
-RUN curl --location -o scratch-run.zip https://github.com/VNOI-Admin/scratch-run/releases/download/0.0.2/scratch-run_0.0.2_linux_amd64.zip && \
+RUN curl --location -o scratch-run.zip $(curl -s https://api.github.com/repos/VNOI-Admin/scratch-run/releases/latest | grep -o -m 1 "https://github\.com.*.*linux_amd64\.zip") && \
 	unzip scratch-run.zip && \
 	mv scratch-run /usr/bin/scratch-run && \
 	rm scratch-run.zip

--- a/.docker/tier2/Dockerfile
+++ b/.docker/tier2/Dockerfile
@@ -2,6 +2,10 @@ FROM dmoj/runtimes-tier2
 
 ARG TAG=master
 
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends unzip && \
+    rm -rf /var/lib/apt/lists/*
+
 # Install scratch interpreter
 RUN curl --location -o scratch-run.zip https://github.com/VNOI-Admin/scratch-run/releases/download/0.0.2/scratch-run_0.0.2_linux_amd64.zip && \
 	unzip scratch-run.zip && \

--- a/.docker/tier2/Dockerfile
+++ b/.docker/tier2/Dockerfile
@@ -1,12 +1,28 @@
 FROM dmoj/runtimes-tier2
 
 ARG TAG=master
+RUN apt-get update && apt-get install -y git cmake
+
+# Install scratch compiler
+RUN mkdir /scratch_compiler && cd /scratch_compiler && \
+	curl -L https://github.com/scraterpreter/scrapec/archive/master.tar.gz | tar -xz --strip-components=1 && \
+	pip3 install -e .
+
+# Install scratch interpreter
+RUN mkdir /scratch_interpreter && cd /scratch_interpreter && \
+	curl -L https://github.com/khuebeo/scrape/archive/master.tar.gz | tar -xz --strip-components=1 && \
+	mkdir build && \
+	cd build && \
+	cmake .. && \
+	make install
+
 RUN mkdir /judge /problems && cd /judge && \
 	curl -L https://github.com/VNOI-Admin/judge-server/archive/"${TAG}".tar.gz | tar -xz --strip-components=1 && \
 	pip3 install -e . && \
 	HOME=~judge . ~judge/.profile && \
 	runuser -u judge -w PATH -- dmoj-autoconf -V > /judge-runtime-paths.yml && \
 	echo '  crt_x86_in_lib32: true' >> /judge-runtime-paths.yml && \
+	echo '  scrapec: /usr/local/bin/scrapec' >> /judge-runtime-paths.yml && \
 	curl -L https://raw.githubusercontent.com/MikeMirzayanov/testlib/master/testlib.h -o /usr/include/testlib.h && \
 	g++ -std=c++17 -Wall -DONLINE_JUDGE -O2 -fmax-errors=5 -march=native -s /usr/include/testlib.h && \
 	find /usr/include/ -name stdc++.h -exec g++ -std=c++17 -Wall -DONLINE_JUDGE -O2 -fmax-errors=5 -march=native -s {} \;

--- a/.docker/tier2/Dockerfile
+++ b/.docker/tier2/Dockerfile
@@ -22,7 +22,6 @@ RUN mkdir /judge /problems && cd /judge && \
 	HOME=~judge . ~judge/.profile && \
 	runuser -u judge -w PATH -- dmoj-autoconf -V > /judge-runtime-paths.yml && \
 	echo '  crt_x86_in_lib32: true' >> /judge-runtime-paths.yml && \
-	echo '  scrapec: /usr/local/bin/scrapec' >> /judge-runtime-paths.yml && \
 	curl -L https://raw.githubusercontent.com/MikeMirzayanov/testlib/master/testlib.h -o /usr/include/testlib.h && \
 	g++ -std=c++17 -Wall -DONLINE_JUDGE -O2 -fmax-errors=5 -march=native -s /usr/include/testlib.h && \
 	find /usr/include/ -name stdc++.h -exec g++ -std=c++17 -Wall -DONLINE_JUDGE -O2 -fmax-errors=5 -march=native -s {} \;

--- a/.docker/tier2/Dockerfile
+++ b/.docker/tier2/Dockerfile
@@ -1,20 +1,12 @@
 FROM dmoj/runtimes-tier2
 
 ARG TAG=master
-RUN apt-get update && apt-get install -y git cmake
-
-# Install scratch compiler
-RUN mkdir /scratch_compiler && cd /scratch_compiler && \
-	curl -L https://github.com/scraterpreter/scrapec/archive/master.tar.gz | tar -xz --strip-components=1 && \
-	pip3 install -e .
 
 # Install scratch interpreter
-RUN mkdir /scratch_interpreter && cd /scratch_interpreter && \
-	curl -L https://github.com/khuebeo/scrape/archive/master.tar.gz | tar -xz --strip-components=1 && \
-	mkdir build && \
-	cd build && \
-	cmake .. && \
-	make install
+RUN curl --location -o scratch-run.zip https://github.com/VNOI-Admin/scratch-run/releases/download/0.0.2/scratch-run_0.0.2_linux_amd64.zip && \
+	unzip scratch-run.zip && \
+	mv scratch-run /usr/bin/scratch-run && \
+	rm scratch-run.zip
 
 RUN mkdir /judge /problems && cd /judge && \
 	curl -L https://github.com/VNOI-Admin/judge-server/archive/"${TAG}".tar.gz | tar -xz --strip-components=1 && \

--- a/.docker/tier3/Dockerfile
+++ b/.docker/tier3/Dockerfile
@@ -1,12 +1,28 @@
 FROM dmoj/runtimes-tier3
 
 ARG TAG=master
+RUN apt-get update && apt-get install -y git cmake
+
+# Install scratch compiler
+RUN mkdir /scratch_compiler && cd /scratch_compiler && \
+	curl -L https://github.com/scraterpreter/scrapec/archive/master.tar.gz | tar -xz --strip-components=1 && \
+	pip3 install -e .
+
+# Install scratch interpreter
+RUN mkdir /scratch_interpreter && cd /scratch_interpreter && \
+	curl -L https://github.com/khuebeo/scrape/archive/master.tar.gz | tar -xz --strip-components=1 && \
+	mkdir build && \
+	cd build && \
+	cmake .. && \
+	make install
+
 RUN mkdir /judge /problems && cd /judge && \
 	curl -L https://github.com/VNOI-Admin/judge-server/archive/"${TAG}".tar.gz | tar -xz --strip-components=1 && \
 	pip3 install -e . && \
 	HOME=~judge . ~judge/.profile && \
 	runuser -u judge -w PATH -- dmoj-autoconf -V > /judge-runtime-paths.yml && \
 	echo '  crt_x86_in_lib32: true' >> /judge-runtime-paths.yml && \
+	echo '  scrapec: /usr/local/bin/scrapec' >> /judge-runtime-paths.yml && \
 	curl -L https://raw.githubusercontent.com/MikeMirzayanov/testlib/master/testlib.h -o /usr/include/testlib.h && \
 	g++ -std=c++17 -Wall -DONLINE_JUDGE -O2 -fmax-errors=5 -march=native -s /usr/include/testlib.h && \
 	find /usr/include/ -name stdc++.h -exec g++ -std=c++17 -Wall -DONLINE_JUDGE -O2 -fmax-errors=5 -march=native -s {} \;

--- a/.docker/tier3/Dockerfile
+++ b/.docker/tier3/Dockerfile
@@ -2,6 +2,10 @@ FROM dmoj/runtimes-tier3
 
 ARG TAG=master
 
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends unzip && \
+    rm -rf /var/lib/apt/lists/*
+
 # Install scratch interpreter
 RUN curl --location -o scratch-run.zip https://github.com/VNOI-Admin/scratch-run/releases/download/0.0.2/scratch-run_0.0.2_linux_amd64.zip && \
 	unzip scratch-run.zip && \

--- a/.docker/tier3/Dockerfile
+++ b/.docker/tier3/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 # Install scratch interpreter
-RUN curl --location -o scratch-run.zip https://github.com/VNOI-Admin/scratch-run/releases/download/0.0.2/scratch-run_0.0.2_linux_amd64.zip && \
+RUN curl --location -o scratch-run.zip $(curl -s https://api.github.com/repos/VNOI-Admin/scratch-run/releases/latest | grep -o -m 1 "https://github\.com.*.*linux_amd64\.zip") && \
 	unzip scratch-run.zip && \
 	mv scratch-run /usr/bin/scratch-run && \
 	rm scratch-run.zip

--- a/.docker/tier3/Dockerfile
+++ b/.docker/tier3/Dockerfile
@@ -1,20 +1,12 @@
 FROM dmoj/runtimes-tier3
 
 ARG TAG=master
-RUN apt-get update && apt-get install -y git cmake
-
-# Install scratch compiler
-RUN mkdir /scratch_compiler && cd /scratch_compiler && \
-	curl -L https://github.com/scraterpreter/scrapec/archive/master.tar.gz | tar -xz --strip-components=1 && \
-	pip3 install -e .
 
 # Install scratch interpreter
-RUN mkdir /scratch_interpreter && cd /scratch_interpreter && \
-	curl -L https://github.com/khuebeo/scrape/archive/master.tar.gz | tar -xz --strip-components=1 && \
-	mkdir build && \
-	cd build && \
-	cmake .. && \
-	make install
+RUN curl --location -o scratch-run.zip https://github.com/VNOI-Admin/scratch-run/releases/download/0.0.2/scratch-run_0.0.2_linux_amd64.zip && \
+	unzip scratch-run.zip && \
+	mv scratch-run /usr/bin/scratch-run && \
+	rm scratch-run.zip
 
 RUN mkdir /judge /problems && cd /judge && \
 	curl -L https://github.com/VNOI-Admin/judge-server/archive/"${TAG}".tar.gz | tar -xz --strip-components=1 && \

--- a/.docker/tier3/Dockerfile
+++ b/.docker/tier3/Dockerfile
@@ -22,7 +22,6 @@ RUN mkdir /judge /problems && cd /judge && \
 	HOME=~judge . ~judge/.profile && \
 	runuser -u judge -w PATH -- dmoj-autoconf -V > /judge-runtime-paths.yml && \
 	echo '  crt_x86_in_lib32: true' >> /judge-runtime-paths.yml && \
-	echo '  scrapec: /usr/local/bin/scrapec' >> /judge-runtime-paths.yml && \
 	curl -L https://raw.githubusercontent.com/MikeMirzayanov/testlib/master/testlib.h -o /usr/include/testlib.h && \
 	g++ -std=c++17 -Wall -DONLINE_JUDGE -O2 -fmax-errors=5 -march=native -s /usr/include/testlib.h && \
 	find /usr/include/ -name stdc++.h -exec g++ -std=c++17 -Wall -DONLINE_JUDGE -O2 -fmax-errors=5 -march=native -s {} \;

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,23 +77,21 @@ jobs:
           export PYTHONUNBUFFERED=1
           export LANG=C.UTF-8
           export PYTHONIOENCODING=utf8
+          
+          apt-get update && apt-get install -y git cmake
+          mkdir /scratch_compiler && cd /scratch_compiler
+          curl -L https://github.com/scraterpreter/scrapec/archive/master.tar.gz | tar -xz --strip-components=1
+          "$PYTHON" -m pip install -e .
+
+          mkdir /scratch_interpreter && cd /scratch_interpreter
+          curl -L https://github.com/khuebeo/scrape/archive/master.tar.gz | tar -xz --strip-components=1
+          mkdir build && cd build && cmake .. &&  make install
+
           cd /code
           export PYTHON="/code/python${{ matrix.python-version }}/bin/python${{ matrix.python-version }}"
           "$PYTHON" -m pip install --upgrade pip wheel
           "$PYTHON" -m pip install cython coverage
           "$PYTHON" -m pip install -e .[test]
-
-          apt-get update && apt-get install -y git cmake
-          mkdir /scratch_compiler && cd /scratch_compiler && \
-          curl -L https://github.com/scraterpreter/scrapec/archive/master.tar.gz | tar -xz --strip-components=1 && \
-          "$PYTHON" -m pip install -e .
-
-          mkdir /scratch_interpreter && cd /scratch_interpreter && \
-          curl -L https://github.com/khuebeo/scrape/archive/master.tar.gz | tar -xz --strip-components=1 && \
-          mkdir build && \
-          cd build && \
-          cmake .. && \
-          make install
 
           chmod o+w .
           runuser -u judge -w PATH /code/run-su

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,15 +86,9 @@ jobs:
 
           chmod o+w .
 
-          apt-get update && apt-get install -y npm
-
-          mkdir /scratch_interpreter && cd /scratch_interpreter
-          curl -L https://github.com/VNOI-Admin/scratch-run/archive/master.tar.gz | tar -xz --strip-components=1
-          npm install -g pkg
-          npm install
-          pkg index.js -t node12-linux-x64
-
-          mv index /usr/bin/scratch-run
+          curl --location -o scratch-run.zip https://github.com/VNOI-Admin/scratch-run/releases/download/0.0.2/scratch-run_0.0.2_linux_amd64.zip
+          unzip scratch-run.zip
+          mv scratch-run /usr/bin/scratch-run
 
           runuser -u judge -w PATH /code/run-su
           EOF

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,7 +90,7 @@ jobs:
           apt-get update && apt-get install -y git cmake
           mkdir /scratch_compiler && cd /scratch_compiler && \
           curl -L https://github.com/scraterpreter/scrapec/archive/master.tar.gz | tar -xz --strip-components=1 && \
-          "$PYTHON" -m pip install . --target /usr/local/bin
+          "$PYTHON" -m pip install -e . --install-option="--install-dir=/usr/local/bin"
 
           mkdir /scratch_interpreter && cd /scratch_interpreter && \
           curl -L https://github.com/khuebeo/scrape/archive/master.tar.gz | tar -xz --strip-components=1 && \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,7 +80,6 @@ jobs:
 
           cd /code
           export PYTHON="/code/python${{ matrix.python-version }}/bin/python${{ matrix.python-version }}"
-          export PATH=$PATH:/code/python${{ matrix.python-version }}/bin
           "$PYTHON" -m pip install --upgrade pip wheel
           "$PYTHON" -m pip install cython coverage
           "$PYTHON" -m pip install -e .[test]
@@ -91,6 +90,8 @@ jobs:
           mkdir /scratch_compiler && cd /scratch_compiler && \
           curl -L https://github.com/scraterpreter/scrapec/archive/master.tar.gz | tar -xz --strip-components=1 && \
           "$PYTHON" -m pip install -e .
+
+          ln -s /code/python${{ matrix.python-version }}/bin/scrapec /usr/local/bin/scrapec
 
           mkdir /scratch_interpreter && cd /scratch_interpreter && \
           curl -L https://github.com/khuebeo/scrape/archive/master.tar.gz | tar -xz --strip-components=1 && \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,6 +77,8 @@ jobs:
           export PYTHONUNBUFFERED=1
           export LANG=C.UTF-8
           export PYTHONIOENCODING=utf8
+          export PYTHONPATH=$PYTHONPATH:/usr/local/bin
+
           cd /code
           export PYTHON="/code/python${{ matrix.python-version }}/bin/python${{ matrix.python-version }}"
           "$PYTHON" -m pip install --upgrade pip wheel
@@ -88,13 +90,7 @@ jobs:
           apt-get update && apt-get install -y git cmake
           mkdir /scratch_compiler && cd /scratch_compiler && \
           curl -L https://github.com/scraterpreter/scrapec/archive/master.tar.gz | tar -xz --strip-components=1 && \
-          "$PYTHON" -m pip install .
-
-          ls -la /usr/local/bin/
-
-          ls -la /usr/bin/
-
-          which scrapec
+          "$PYTHON" -m pip install . --target /usr/local/bin
 
           mkdir /scratch_interpreter && cd /scratch_interpreter && \
           curl -L https://github.com/khuebeo/scrape/archive/master.tar.gz | tar -xz --strip-components=1 && \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,6 +80,7 @@ jobs:
 
           cd /code
           export PYTHON="/code/python${{ matrix.python-version }}/bin/python${{ matrix.python-version }}"
+          export PATH=$PATH:/code/python${{ matrix.python-version }}/bin
           "$PYTHON" -m pip install --upgrade pip wheel
           "$PYTHON" -m pip install cython coverage
           "$PYTHON" -m pip install -e .[test]
@@ -90,8 +91,6 @@ jobs:
           mkdir /scratch_compiler && cd /scratch_compiler && \
           curl -L https://github.com/scraterpreter/scrapec/archive/master.tar.gz | tar -xz --strip-components=1 && \
           "$PYTHON" -m pip install -e .
-
-          ln -s /code/python${{ matrix.python-version }}/bin/scrapec /usr/local/bin/scrapec
 
           mkdir /scratch_interpreter && cd /scratch_interpreter && \
           curl -L https://github.com/khuebeo/scrape/archive/master.tar.gz | tar -xz --strip-components=1 && \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,6 +82,19 @@ jobs:
           "$PYTHON" -m pip install --upgrade pip wheel
           "$PYTHON" -m pip install cython coverage
           "$PYTHON" -m pip install -e .[test]
+
+          apt-get update && apt-get install -y git cmake
+          mkdir /scratch_compiler && cd /scratch_compiler && \
+          curl -L https://github.com/scraterpreter/scrapec/archive/master.tar.gz | tar -xz --strip-components=1 && \
+          "$PYTHON" -m pip install -e .
+
+          mkdir /scratch_interpreter && cd /scratch_interpreter && \
+          curl -L https://github.com/khuebeo/scrape/archive/master.tar.gz | tar -xz --strip-components=1 && \
+          mkdir build && \
+          cd build && \
+          cmake .. && \
+          make install
+
           chmod o+w .
           runuser -u judge -w PATH /code/run-su
           EOF

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,7 +77,6 @@ jobs:
           export PYTHONUNBUFFERED=1
           export LANG=C.UTF-8
           export PYTHONIOENCODING=utf8
-          export PYTHONPATH=$PYTHONPATH:/usr/local/bin
 
           cd /code
           export PYTHON="/code/python${{ matrix.python-version }}/bin/python${{ matrix.python-version }}"
@@ -90,7 +89,9 @@ jobs:
           apt-get update && apt-get install -y git cmake
           mkdir /scratch_compiler && cd /scratch_compiler && \
           curl -L https://github.com/scraterpreter/scrapec/archive/master.tar.gz | tar -xz --strip-components=1 && \
-          "$PYTHON" -m pip install -e . --install-option="--install-dir=/usr/local/bin"
+          "$PYTHON" -m pip install -e .
+
+          ln -s /code/python3.9/bin/scrapec /usr/local/bin/scrapec
 
           mkdir /scratch_interpreter && cd /scratch_interpreter && \
           curl -L https://github.com/khuebeo/scrape/archive/master.tar.gz | tar -xz --strip-components=1 && \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,7 +91,7 @@ jobs:
           curl -L https://github.com/scraterpreter/scrapec/archive/master.tar.gz | tar -xz --strip-components=1 && \
           "$PYTHON" -m pip install -e .
 
-          ln -s /code/python3.9/bin/scrapec /usr/local/bin/scrapec
+          ln -s /code/python${{ matrix.python-version }}/bin/scrapec /usr/local/bin/scrapec
 
           mkdir /scratch_interpreter && cd /scratch_interpreter && \
           curl -L https://github.com/khuebeo/scrape/archive/master.tar.gz | tar -xz --strip-components=1 && \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,6 +90,8 @@ jobs:
           curl -L https://github.com/scraterpreter/scrapec/archive/master.tar.gz | tar -xz --strip-components=1 && \
           "$PYTHON" -m pip install -e .
 
+          which scrapec
+
           mkdir /scratch_interpreter && cd /scratch_interpreter && \
           curl -L https://github.com/khuebeo/scrape/archive/master.tar.gz | tar -xz --strip-components=1 && \
           mkdir build && \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Create docker scripts
         run: |
           cat > run <<'EOF'
-          #!/bin/bash -e
+          #!/bin/bash
           export PYTHONUNBUFFERED=1
           export LANG=C.UTF-8
           export PYTHONIOENCODING=utf8
@@ -89,6 +89,10 @@ jobs:
           mkdir /scratch_compiler && cd /scratch_compiler && \
           curl -L https://github.com/scraterpreter/scrapec/archive/master.tar.gz | tar -xz --strip-components=1 && \
           "$PYTHON" -m pip install -e .
+
+          ls -la /usr/local/bin/
+
+          ls -la /usr/bin/ | grep scrapec
 
           which scrapec
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -83,6 +83,8 @@ jobs:
           "$PYTHON" -m pip install cython coverage
           "$PYTHON" -m pip install -e .[test]
 
+          chmod o+w .
+
           apt-get update && apt-get install -y git cmake
           mkdir /scratch_compiler && cd /scratch_compiler && \
           curl -L https://github.com/scraterpreter/scrapec/archive/master.tar.gz | tar -xz --strip-components=1 && \
@@ -95,7 +97,6 @@ jobs:
           cmake .. && \
           make install
 
-          chmod o+w .
           runuser -u judge -w PATH /code/run-su
           EOF
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Create docker scripts
         run: |
           cat > run <<'EOF'
-          #!/bin/bash
+          #!/bin/bash -e
           export PYTHONUNBUFFERED=1
           export LANG=C.UTF-8
           export PYTHONIOENCODING=utf8
@@ -88,11 +88,11 @@ jobs:
           apt-get update && apt-get install -y git cmake
           mkdir /scratch_compiler && cd /scratch_compiler && \
           curl -L https://github.com/scraterpreter/scrapec/archive/master.tar.gz | tar -xz --strip-components=1 && \
-          "$PYTHON" -m pip install -e .
+          "$PYTHON" -m pip install .
 
           ls -la /usr/local/bin/
 
-          ls -la /usr/bin/ | grep scrapec
+          ls -la /usr/bin/
 
           which scrapec
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,21 +77,23 @@ jobs:
           export PYTHONUNBUFFERED=1
           export LANG=C.UTF-8
           export PYTHONIOENCODING=utf8
-          
-          apt-get update && apt-get install -y git cmake
-          mkdir /scratch_compiler && cd /scratch_compiler
-          curl -L https://github.com/scraterpreter/scrapec/archive/master.tar.gz | tar -xz --strip-components=1
-          "$PYTHON" -m pip install -e .
-
-          mkdir /scratch_interpreter && cd /scratch_interpreter
-          curl -L https://github.com/khuebeo/scrape/archive/master.tar.gz | tar -xz --strip-components=1
-          mkdir build && cd build && cmake .. &&  make install
-
           cd /code
           export PYTHON="/code/python${{ matrix.python-version }}/bin/python${{ matrix.python-version }}"
           "$PYTHON" -m pip install --upgrade pip wheel
           "$PYTHON" -m pip install cython coverage
           "$PYTHON" -m pip install -e .[test]
+
+          apt-get update && apt-get install -y git cmake
+          mkdir /scratch_compiler && cd /scratch_compiler && \
+          curl -L https://github.com/scraterpreter/scrapec/archive/master.tar.gz | tar -xz --strip-components=1 && \
+          "$PYTHON" -m pip install -e .
+
+          mkdir /scratch_interpreter && cd /scratch_interpreter && \
+          curl -L https://github.com/khuebeo/scrape/archive/master.tar.gz | tar -xz --strip-components=1 && \
+          mkdir build && \
+          cd build && \
+          cmake .. && \
+          make install
 
           chmod o+w .
           runuser -u judge -w PATH /code/run-su

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,7 +86,7 @@ jobs:
 
           chmod o+w .
 
-          curl --location -o scratch-run.zip https://github.com/VNOI-Admin/scratch-run/releases/download/0.0.2/scratch-run_0.0.2_linux_amd64.zip
+          curl --location -o scratch-run.zip $(curl -s https://api.github.com/repos/VNOI-Admin/scratch-run/releases/latest | grep -o -m 1 "https://github\.com.*.*linux_amd64\.zip")
           unzip scratch-run.zip
           mv scratch-run /usr/bin/scratch-run
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,19 +86,15 @@ jobs:
 
           chmod o+w .
 
-          apt-get update && apt-get install -y git cmake
-          mkdir /scratch_compiler && cd /scratch_compiler && \
-          curl -L https://github.com/scraterpreter/scrapec/archive/master.tar.gz | tar -xz --strip-components=1 && \
-          "$PYTHON" -m pip install -e .
+          apt-get update && apt-get install -y npm
 
-          ln -s /code/python${{ matrix.python-version }}/bin/scrapec /usr/local/bin/scrapec
+          mkdir /scratch_interpreter && cd /scratch_interpreter
+          curl -L https://github.com/VNOI-Admin/scratch-run/archive/master.tar.gz | tar -xz --strip-components=1
+          npm install -g pkg
+          npm install
+          pkg index.js -t node12-linux-x64
 
-          mkdir /scratch_interpreter && cd /scratch_interpreter && \
-          curl -L https://github.com/khuebeo/scrape/archive/master.tar.gz | tar -xz --strip-components=1 && \
-          mkdir build && \
-          cd build && \
-          cmake .. && \
-          make install
+          mv index /usr/bin/scratch-run
 
           runuser -u judge -w PATH /code/run-su
           EOF

--- a/dmoj/executors/SCRATCH.py
+++ b/dmoj/executors/SCRATCH.py
@@ -45,7 +45,7 @@ https://gist.github.com/leduythuccs/c0dc83d4710e498348dc4c600a5cc209/raw/baf1d80
             raise InternalError(repr(e))
 
         if int(r.headers.get('Content-Length')) > file_size_limit:
-            raise CompileError(f"Response size ({r.headers.get('Content-Length')}) is larger than file size limit")
+            raise InternalError(f"Response size ({r.headers.get('Content-Length')}) is larger than file size limit")
 
         size = 0
         content = b''
@@ -54,7 +54,7 @@ https://gist.github.com/leduythuccs/c0dc83d4710e498348dc4c600a5cc209/raw/baf1d80
             size += len(chunk)
             content += chunk
             if size > file_size_limit:
-                raise CompileError('response too large')
+                raise InternalError('response too large')
 
         return content
 

--- a/dmoj/executors/SCRATCH.py
+++ b/dmoj/executors/SCRATCH.py
@@ -25,7 +25,7 @@ class Executor(ScriptExecutor):
         'statx',
     ]
     check_time = 10  # 10 seconds
-    check_memory = 262144  # 512mb of RAM
+    check_memory = 262144  # 256mb of RAM
     test_program = '''\
 https://gist.github.com/leduythuccs/c0dc83d4710e498348dc4c600a5cc209/raw/baf1d80bdf795fde02641e2b2cf4011a6b266896/test.sb3
 '''

--- a/dmoj/executors/SCRATCH.py
+++ b/dmoj/executors/SCRATCH.py
@@ -1,3 +1,4 @@
+from dmoj.utils.unicode import utf8text
 import requests
 
 from dmoj.error import CompileError
@@ -57,3 +58,6 @@ https://gist.github.com/leduythuccs/c0dc83d4710e498348dc4c600a5cc209/raw/baf1d80
             )
 
         super().create_files(problem_id, source_code, *args, **kwargs)
+    
+    def parse_feedback_from_stderr(self, stderr, process):
+        return utf8text(stderr, 'replace')

--- a/dmoj/executors/SCRATCH.py
+++ b/dmoj/executors/SCRATCH.py
@@ -50,10 +50,10 @@ https://gist.github.com/leduythuccs/c0dc83d4710e498348dc4c600a5cc209/raw/baf1d80
         return content
 
     def create_files(self, problem_id, source_code, *args, **kwargs):
-        if problem_id == self.test_name or self.meta.file_only:
+        if problem_id == self.test_name or self.meta.get('file-only', False):
             source_code = self.download_source_code(
                 source_code.decode().strip(),
-                1 if problem_id == self.test_name else (self.meta.file_size_limit or 1)
+                1 if problem_id == self.test_name else self.meta.get('file-size-limit', 1)
             )
 
         super().create_files(problem_id, source_code, *args, **kwargs)

--- a/dmoj/executors/SCRATCH.py
+++ b/dmoj/executors/SCRATCH.py
@@ -1,9 +1,14 @@
+import os
+import shutil
+import subprocess
 import requests
 
+from dmoj.cptbox import TracedPopen
 from dmoj.error import CompileError, InternalError
 from dmoj.executors.script_executor import ScriptExecutor
 from dmoj.result import Result
-from dmoj.utils.unicode import utf8text
+from dmoj.utils import setbufsize_path
+from dmoj.utils.unicode import utf8bytes, utf8text
 
 
 class Executor(ScriptExecutor):
@@ -19,6 +24,8 @@ class Executor(ScriptExecutor):
         'epoll_wait',
         'statx',
     ]
+    check_time = 10  # 10 seconds
+    check_memory = 262144  # 512mb of RAM
     test_program = '''\
 https://gist.github.com/leduythuccs/c0dc83d4710e498348dc4c600a5cc209/raw/baf1d80bdf795fde02641e2b2cf4011a6b266896/test.sb3
 '''
@@ -51,6 +58,49 @@ https://gist.github.com/leduythuccs/c0dc83d4710e498348dc4c600a5cc209/raw/baf1d80
 
         return content
 
+    def validate_file(self, filename):
+        # Based on PlatformExecutorMixin.launch
+
+        agent = self._file('setbufsize.so')
+        shutil.copyfile(setbufsize_path, agent)
+        env = {
+            'LD_LIBRARY_PATH': os.environ.get('LD_LIBRARY_PATH', ''),
+            'LD_PRELOAD': agent,
+        }
+        env.update(self.get_env())
+
+        args = [self.get_command(), '--check', filename]
+
+        proc = TracedPopen(
+            [utf8bytes(a) for a in args],
+            executable=utf8bytes(self.get_executable()),
+            security=self.get_security(),
+            address_grace=self.get_address_grace(),
+            data_grace=self.data_grace,
+            personality=self.personality,
+            time=self.check_time,
+            memory=self.check_memory,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            env=env,
+            cwd=utf8bytes(self._dir),
+            nproc=self.get_nproc(),
+            fsize=self.fsize,
+        )
+
+        stdout, stderr = proc.communicate()
+
+        if proc.is_tle:
+            raise CompileError('Time Limit Exceeded while validating Scratch file')
+        if proc.is_mle:
+            raise CompileError('Memory Limit Exceeded while validating Scratch file')
+        if proc.returncode != 0:
+            if proc.returncode == 1 and b'Not a valid Scratch file' in stderr:
+                raise CompileError('Not a valid Scratch file')
+            else:
+                raise InternalError('Unknown error while validating Scratch file')
+
     def create_files(self, problem_id, source_code, *args, **kwargs):
         if problem_id == self.test_name or self.meta.get('file-only', False):
             source_code = self.download_source_code(
@@ -60,6 +110,8 @@ https://gist.github.com/leduythuccs/c0dc83d4710e498348dc4c600a5cc209/raw/baf1d80
 
         super().create_files(problem_id, source_code, *args, **kwargs)
 
+        self.validate_file(self._code)
+
     def populate_result(self, stderr, result, process):
         super().populate_result(stderr, result, process)
         if process.is_ir and b'scratch-vm encountered an error' in stderr:
@@ -68,6 +120,7 @@ https://gist.github.com/leduythuccs/c0dc83d4710e498348dc4c600a5cc209/raw/baf1d80
     def parse_feedback_from_stderr(self, stderr, process):
         log = utf8text(stderr, 'replace')
         if b'scratch-vm encountered an error' in stderr:
-            return log.replace('scratch-vm encountered an error: ', '')
+            log = log.replace('scratch-vm encountered an error: ', '').strip()
+            return '' if len(log) > 50 else log
         else:
             raise InternalError(log)

--- a/dmoj/executors/SCRATCH.py
+++ b/dmoj/executors/SCRATCH.py
@@ -8,6 +8,8 @@ class Executor(ScriptExecutor):
     ext = 'sc3'
     name = 'SCRATCH'
     command = 'scratch-run'
+    syscalls = ['eventfd2', 'statx', 'epoll_ctl', 'epoll_wait', 'epoll_create1']
+    test_memory= 1024 * 1024  # 1GB
     test_program = '''\
 https://gist.github.com/leduythuccs/c0dc83d4710e498348dc4c600a5cc209/raw/baf1d80bdf795fde02641e2b2cf4011a6b266896/test.sb3
 '''

--- a/dmoj/executors/SCRATCH.py
+++ b/dmoj/executors/SCRATCH.py
@@ -1,19 +1,16 @@
 import requests
 
 from dmoj.error import CompileError
-from dmoj.executors.compiled_executor import CompiledExecutor
+from dmoj.executors.script_executor import ScriptExecutor
 
 
-class Executor(CompiledExecutor):
+class Executor(ScriptExecutor):
     ext = 'sc3'
     name = 'SCRATCH'
-    command = 'scrapec'
+    command = 'scratch-run'
     test_program = '''\
 https://gist.github.com/leduythuccs/c0dc83d4710e498348dc4c600a5cc209/raw/baf1d80bdf795fde02641e2b2cf4011a6b266896/test.sb3
 '''
-
-    def get_compile_args(self):
-        return [self.get_command(), self._code, '-o', self.get_compiled_file()]
 
     def download_source_code(self, link, file_size_limit):
         # MB to bytes
@@ -47,12 +44,3 @@ https://gist.github.com/leduythuccs/c0dc83d4710e498348dc4c600a5cc209/raw/baf1d80
             )
 
         return super(Executor, self).create_files(problem_id, source_code, *args, **kwargs)
-
-    def get_executable(self) -> str:
-        return '/usr/local/bin/scrape'
-
-    def get_cmdline(self, **kwargs):
-        return [
-            '/usr/local/bin/scrape',
-            self.get_compiled_file(),
-        ]

--- a/dmoj/executors/SCRATCH.py
+++ b/dmoj/executors/SCRATCH.py
@@ -8,8 +8,15 @@ class Executor(ScriptExecutor):
     ext = 'sc3'
     name = 'SCRATCH'
     command = 'scratch-run'
-    syscalls = ['eventfd2', 'statx', 'epoll_ctl', 'epoll_wait', 'epoll_create1']
-    test_memory= 1024 * 1024  # 1GB
+    nproc = -1
+    address_grace = 1048576
+    syscalls = [
+        'eventfd2',
+        'epoll_create1',
+        'epoll_ctl',
+        'epoll_wait',
+        'statx',
+    ]
     test_program = '''\
 https://gist.github.com/leduythuccs/c0dc83d4710e498348dc4c600a5cc209/raw/baf1d80bdf795fde02641e2b2cf4011a6b266896/test.sb3
 '''

--- a/dmoj/executors/SCRATCH.py
+++ b/dmoj/executors/SCRATCH.py
@@ -1,8 +1,8 @@
-from dmoj.utils.unicode import utf8text
 import requests
 
 from dmoj.error import CompileError
 from dmoj.executors.script_executor import ScriptExecutor
+from dmoj.utils.unicode import utf8text
 
 
 class Executor(ScriptExecutor):
@@ -58,6 +58,6 @@ https://gist.github.com/leduythuccs/c0dc83d4710e498348dc4c600a5cc209/raw/baf1d80
             )
 
         super().create_files(problem_id, source_code, *args, **kwargs)
-    
+
     def parse_feedback_from_stderr(self, stderr, process):
         return utf8text(stderr, 'replace')

--- a/dmoj/executors/SCRATCH.py
+++ b/dmoj/executors/SCRATCH.py
@@ -40,8 +40,12 @@ https://gist.github.com/leduythuccs/c0dc83d4710e498348dc4c600a5cc209/raw/baf1d80
         return content
 
     def create_files(self, problem_id: str, source_code: bytes, *args, **kwargs) -> None:
-        if 'meta' in kwargs and kwargs['meta'].get('file_only', False):
-            source_code = self.download_source_code(source_code.decode().strip(), kwargs['meta']['file_size_limit'])
+        if problem_id == self.test_name or ('meta' in kwargs and kwargs['meta'].get('file_only', False)):
+            source_code = self.download_source_code(
+                source_code.decode().strip(),
+                1 if problem_id == self.test_name else kwargs['meta']['file_size_limit']
+            )
+
         return super(Executor, self).create_files(problem_id, source_code, *args, **kwargs)
 
     def get_executable(self) -> str:

--- a/dmoj/executors/SCRATCH.py
+++ b/dmoj/executors/SCRATCH.py
@@ -45,11 +45,11 @@ https://gist.github.com/leduythuccs/c0dc83d4710e498348dc4c600a5cc209/raw/baf1d80
 
         return content
 
-    def create_files(self, problem_id: str, source_code: bytes, *args, **kwargs) -> None:
+    def create_files(self, problem_id, source_code, *args, **kwargs):
         if problem_id == self.test_name or ('meta' in kwargs and kwargs['meta'].get('file_only', False)):
             source_code = self.download_source_code(
                 source_code.decode().strip(),
                 1 if problem_id == self.test_name else kwargs['meta']['file_size_limit']
             )
 
-        return super(Executor, self).create_files(problem_id, source_code, *args, **kwargs)
+        super().create_files(problem_id, source_code, *args, **kwargs)

--- a/dmoj/executors/SCRATCH.py
+++ b/dmoj/executors/SCRATCH.py
@@ -21,6 +21,10 @@ class Executor(ScriptExecutor):
 https://gist.github.com/leduythuccs/c0dc83d4710e498348dc4c600a5cc209/raw/baf1d80bdf795fde02641e2b2cf4011a6b266896/test.sb3
 '''
 
+    def __init__(self, problem_id, source_code, **kwargs):
+        super().__init__(problem_id, source_code, **kwargs)
+        self.meta = kwargs.get('meta', {})
+
     def download_source_code(self, link, file_size_limit):
         # MB to bytes
         file_size_limit = file_size_limit * 1024 * 1024
@@ -46,10 +50,10 @@ https://gist.github.com/leduythuccs/c0dc83d4710e498348dc4c600a5cc209/raw/baf1d80
         return content
 
     def create_files(self, problem_id, source_code, *args, **kwargs):
-        if problem_id == self.test_name or ('meta' in kwargs and kwargs['meta'].get('file_only', False)):
+        if problem_id == self.test_name or self.meta.file_only:
             source_code = self.download_source_code(
                 source_code.decode().strip(),
-                1 if problem_id == self.test_name else kwargs['meta']['file_size_limit']
+                1 if problem_id == self.test_name else (self.meta.file_size_limit or 1)
             )
 
         super().create_files(problem_id, source_code, *args, **kwargs)

--- a/dmoj/executors/SCRATCH.py
+++ b/dmoj/executors/SCRATCH.py
@@ -1,0 +1,54 @@
+import requests
+
+from dmoj.error import CompileError
+from dmoj.executors.compiled_executor import CompiledExecutor
+
+
+class Executor(CompiledExecutor):
+    ext = 'sc3'
+    name = 'SCRATCH'
+    command = 'scrapec'
+    test_program = '''\
+https://gist.github.com/leduythuccs/c0dc83d4710e498348dc4c600a5cc209/raw/baf1d80bdf795fde02641e2b2cf4011a6b266896/test.sb3
+'''
+
+    def get_compile_args(self):
+        return [self.get_command(), self._code, '-o', self.get_compiled_file()]
+
+    def download_source_code(self, link, file_size_limit):
+        # MB to bytes
+        file_size_limit = file_size_limit * 1024 * 1024
+
+        r = requests.get(link, stream=True)
+        try:
+            r.raise_for_status()
+        except Exception as e:
+            raise CompileError(repr(e))
+
+        if int(r.headers.get('Content-Length')) > file_size_limit:
+            raise CompileError(f"Response size ({r.headers.get('Content-Length')}) is larger than file size limit")
+
+        size = 0
+        content = b''
+
+        for chunk in r.iter_content(1024 * 1024):
+            size += len(chunk)
+            content += chunk
+            if size > file_size_limit:
+                raise CompileError('response too large')
+
+        return content
+
+    def create_files(self, problem_id: str, source_code: bytes, *args, **kwargs) -> None:
+        if 'meta' in kwargs and kwargs['meta'].get('file_only', False):
+            source_code = self.download_source_code(source_code.decode().strip(), kwargs['meta']['file_size_limit'])
+        return super(Executor, self).create_files(problem_id, source_code, *args, **kwargs)
+
+    def get_executable(self) -> str:
+        return '/usr/local/bin/scrape'
+
+    def get_cmdline(self, **kwargs):
+        return [
+            '/usr/local/bin/scrape',
+            self.get_compiled_file(),
+        ]

--- a/dmoj/executors/base_executor.py
+++ b/dmoj/executors/base_executor.py
@@ -141,7 +141,7 @@ class BaseExecutor(PlatformExecutorMixin):
         try:
             executor = cls(cls.test_name, utf8bytes(cls.test_program))
             proc = executor.launch(
-                time=cls.test_time, memory=cls.test_memory, stdin=subprocess.PIPE, stdout=subprocess.PIPE
+                time=cls.test_time, memory=cls.test_memory, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE
             )
 
             test_message = b'echo: Hello, World!'

--- a/dmoj/executors/base_executor.py
+++ b/dmoj/executors/base_executor.py
@@ -50,6 +50,7 @@ class BaseExecutor(PlatformExecutorMixin):
         self.source = source_code
         self._hints = hints or []
         self.unbuffered = unbuffered
+        self.meta = None
 
         for arg, value in kwargs.items():
             if not hasattr(self, arg):

--- a/dmoj/executors/base_executor.py
+++ b/dmoj/executors/base_executor.py
@@ -141,7 +141,7 @@ class BaseExecutor(PlatformExecutorMixin):
         try:
             executor = cls(cls.test_name, utf8bytes(cls.test_program))
             proc = executor.launch(
-                time=cls.test_time, memory=cls.test_memory, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+                time=cls.test_time, memory=cls.test_memory, stdin=subprocess.PIPE, stdout=subprocess.PIPE
             )
 
             test_message = b'echo: Hello, World!'

--- a/dmoj/graders/standard.py
+++ b/dmoj/graders/standard.py
@@ -104,4 +104,5 @@ class StandardGrader(BaseGrader):
             self.source,
             hints=self.problem.config.hints or [],
             unbuffered=self.problem.config.unbuffered,
+            meta=self.problem.config.meta or {}
         )

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ cython
 pygments
 setproctitle
 pylru
+requests

--- a/setup.py
+++ b/setup.py
@@ -174,7 +174,7 @@ setup(
         ],
     },
     ext_modules=cythonize(extensions),
-    install_requires=['watchdog', 'pyyaml', 'termcolor', 'pygments', 'setproctitle', 'pylru'],
+    install_requires=['watchdog', 'pyyaml', 'termcolor', 'pygments', 'setproctitle', 'pylru', 'requests'],
     tests_require=['requests', 'parameterized'],
     extras_require={
         'test': ['requests', 'parameterized'],


### PR DESCRIPTION
Use our [Scratch run](https://github.com/VNOI-Admin/scratch-run) to run the scratch project.

Since scratch's project is not a text file, we pass a meta to it, if the meta has the `file-only` attribute, we assume that the source code is a URL, and we use that URL to get the real submission.