### PR TITLE
fix tiervnoj: No Module named 'distutils'

### DIFF
--- a/.docker/tier1/Dockerfile
+++ b/.docker/tier1/Dockerfile
@@ -16,7 +16,7 @@ RUN ARCH=$([ $(uname -m) = "x86_64" ] && echo "amd64" || echo "arm64") && \
 RUN mkdir /judge /problems && cd /judge && \
 	curl -L https://github.com/VNOI-Admin/judge-server/archive/"${TAG}".tar.gz | tar -xz --strip-components=1 && \
 	python3 -m venv --prompt=DMOJ /env && \
-	/env/bin/pip3 install cython && \
+	/env/bin/pip3 install cython setuptools && \
 	/env/bin/pip3 install -e . && \
 	/env/bin/python3 setup.py develop && \
 	HOME=~judge . ~judge/.profile && \

--- a/.docker/tier2/Dockerfile
+++ b/.docker/tier2/Dockerfile
@@ -16,7 +16,7 @@ RUN ARCH=$([ $(uname -m) = "x86_64" ] && echo "amd64" || echo "arm64") && \
 RUN mkdir /judge /problems && cd /judge && \
 	curl -L https://github.com/VNOI-Admin/judge-server/archive/"${TAG}".tar.gz | tar -xz --strip-components=1 && \
 	python3 -m venv --prompt=DMOJ /env && \
-	/env/bin/pip3 install cython && \
+	/env/bin/pip3 install cython setuptools && \
 	/env/bin/pip3 install -e . && \
 	/env/bin/python3 setup.py develop && \
 	HOME=~judge . ~judge/.profile && \

--- a/.docker/tier3/Dockerfile
+++ b/.docker/tier3/Dockerfile
@@ -16,7 +16,7 @@ RUN ARCH=$([ $(uname -m) = "x86_64" ] && echo "amd64" || echo "arm64") && \
 RUN mkdir /judge /problems && cd /judge && \
 	curl -L https://github.com/VNOI-Admin/judge-server/archive/"${TAG}".tar.gz | tar -xz --strip-components=1 && \
 	python3 -m venv --prompt=DMOJ /env && \
-	/env/bin/pip3 install cython && \
+	/env/bin/pip3 install cython setuptools && \
 	/env/bin/pip3 install -e . && \
 	/env/bin/python3 setup.py develop && \
 	HOME=~judge . ~judge/.profile && \

--- a/.docker/tiericpc/Dockerfile
+++ b/.docker/tiericpc/Dockerfile
@@ -5,7 +5,7 @@ ARG TAG=master
 RUN mkdir /judge /problems && cd /judge && \
 	curl -L https://github.com/VNOI-Admin/judge-server/archive/"${TAG}".tar.gz | tar -xz --strip-components=1 && \
 	python3 -m venv --prompt=DMOJ /env && \
-	/env/bin/pip3 install cython && \
+	/env/bin/pip3 install cython setuptools && \
 	/env/bin/pip3 install -e . && \
 	/env/bin/python3 setup.py develop && \
 	HOME=~judge . ~judge/.profile && \

--- a/.docker/tiervnoj/Dockerfile
+++ b/.docker/tiervnoj/Dockerfile
@@ -41,6 +41,7 @@ ENV PATH="/opt/kotlin/bin:/opt/pypy2/bin:/opt/pypy3/bin:/home/judge/.cargo/bin:$
 RUN mkdir /judge /problems && cd /judge && \
 	curl -L https://github.com/VNOI-Admin/judge-server/archive/"${TAG}".tar.gz | tar -xz --strip-components=1 && \
 	python3 -m venv --prompt=DMOJ /env && \
+ 	/env/bin/pip3 install setuptools && \
 	/env/bin/pip3 install cython && \
 	/env/bin/pip3 install -e . && \
 	/env/bin/python3 setup.py develop && \

--- a/.docker/tiervnoj/Dockerfile
+++ b/.docker/tiervnoj/Dockerfile
@@ -41,8 +41,7 @@ ENV PATH="/opt/kotlin/bin:/opt/pypy2/bin:/opt/pypy3/bin:/home/judge/.cargo/bin:$
 RUN mkdir /judge /problems && cd /judge && \
 	curl -L https://github.com/VNOI-Admin/judge-server/archive/"${TAG}".tar.gz | tar -xz --strip-components=1 && \
 	python3 -m venv --prompt=DMOJ /env && \
- 	/env/bin/pip3 install setuptools && \
-	/env/bin/pip3 install cython && \
+	/env/bin/pip3 install cython setuptools && \
 	/env/bin/pip3 install -e . && \
 	/env/bin/python3 setup.py develop && \
 	HOME=~judge . ~judge/.profile && \


### PR DESCRIPTION
Docker is using Python 3.12.4, the module distutils is no longer available on it. Therefore, we need to install setuptools into the environment.

![image](https://github.com/user-attachments/assets/532008f5-4883-4e95-9450-aa4b2bd15acc)
